### PR TITLE
Revamp hero and add contact section

### DIFF
--- a/src/app/components/Home/Contact/index.tsx
+++ b/src/app/components/Home/Contact/index.tsx
@@ -1,0 +1,45 @@
+'use client'
+import React from 'react'
+
+const Contact = () => {
+  return (
+    <section id='contact' className='py-20'>
+      <div className='container mx-auto max-w-7xl px-4 text-center'>
+        <p className='text-primary text-lg font-normal tracking-widest uppercase'>Contact</p>
+        <h2 className='my-6'>Let\'s build something great together</h2>
+        <p className='text-black/50 text-base max-w-3xl mx-auto mb-8'>
+          We\'d love to hear from you. Send us a message and we will respond as soon as possible.
+        </p>
+        <div className='max-w-3xl mx-auto'>
+          <form className='grid gap-6'>
+            <input
+              type='text'
+              className='py-4 px-6 rounded-md bg-grey focus:outline-hidden'
+              placeholder='Your name'
+              autoComplete='off'
+            />
+            <input
+              type='email'
+              className='py-4 px-6 rounded-md bg-grey focus:outline-hidden'
+              placeholder='Your email'
+              autoComplete='off'
+            />
+            <textarea
+              className='py-4 px-6 rounded-md bg-grey focus:outline-hidden h-40'
+              placeholder='Your message'
+              autoComplete='off'
+            />
+            <button
+              type='submit'
+              className='bg-primary text-white text-xl font-semibold py-5 px-12 rounded-full hover:bg-darkmode duration-300 w-fit mx-auto'
+            >
+              Send message
+            </button>
+          </form>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default Contact

--- a/src/app/components/Home/Hero/index.tsx
+++ b/src/app/components/Home/Hero/index.tsx
@@ -1,51 +1,53 @@
 'use client'
 import Link from 'next/link'
-import Image from 'next/image'
 import { motion } from 'framer-motion'
-import { Icon } from '@iconify/react/dist/iconify.js'
 
 const Hero = () => {
-  const leftAnimation = {
-    initial: { x: '-100%', opacity: 0 },
-    animate: { x: 0, opacity: 1 },
-    exit: { x: '-100%', opacity: 0 },
-    transition: { duration: 0.6 },
-  }
-
-  const rightAnimation = {
-    initial: { x: '100%', opacity: 0 },
-    animate: { x: 0, opacity: 1 },
-    exit: { x: '100%', opacity: 0 },
+  const fadeUp = {
+    initial: { opacity: 0, y: 40 },
+    animate: { opacity: 1, y: 0 },
     transition: { duration: 0.6 },
   }
 
   return (
     <section className='relative overflow-hidden z-1'>
       <div className='container mx-auto pt-24 max-w-7xl px-4'>
-        <div className='grid grid-cols-12 justify-center items-center'>
-          <div className='col-span-12 xl:col-span-5 lg:col-span-6 md:col-span-12 sm:col-span-12'>
-            <div className='py-2 px-5 bg-primary/15 rounded-full w-fit'>
-              <p className='text-primary text-lg font-bold'>DESIGN AGENCY</p>
-            </div>
-            <h1>
-              Dedicated to bring your ideas to life.
-            </h1>
-            <Link href={'#'}>
-              <button className='bg-primary text-white text-xl font-semibold py-5 px-12 rounded-full hover:bg-darkmode hover:cursor-pointer mt-10'>
-                Get started
+        <div className='flex flex-col items-center text-center'>
+          <motion.div
+            {...fadeUp}
+            className='py-2 px-5 bg-primary/15 rounded-full mb-6'
+          >
+            <p className='text-primary text-lg font-bold'>CREATIVE AGENCY</p>
+          </motion.div>
+          <motion.h1
+            {...fadeUp}
+            transition={{ duration: 0.6, delay: 0.2 }}
+          >
+            We turn bold ideas into digital reality.
+          </motion.h1>
+          <motion.div
+            {...fadeUp}
+            transition={{ duration: 0.6, delay: 0.4 }}
+            className='mt-10'
+          >
+            <Link href='#contact'>
+              <button className='bg-primary text-white text-xl font-semibold py-5 px-12 rounded-full hover:bg-darkmode hover:cursor-pointer'>
+                Contact now
               </button>
             </Link>
-          </div>
-          <div className='xl:col-span-7 lg:col-span-6 lg:block hidden'>
-            <Image
-              src='/images/hero/banner-image.png'
-              alt='banner image'
-              width={600}
-              height={600}
-              className='w-full'
-            />
-          </div>
+          </motion.div>
         </div>
+        {/*
+        <div className='xl:col-span-7 lg:col-span-6 lg:block hidden'>
+          <Image
+            src='/images/hero/banner-image.png'
+            alt='banner image'
+            width={600}
+            height={600}
+            className='w-full'
+          />
+        </div>
+        */}
       </div>
     </section>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import Manage from '@/app/components/Home/Manage'
 import FAQ from '@/app/components/Home/FAQ'
 import Testimonial from '@/app/components/Home/Testimonials'
 import Articles from '@/app/components/Home/Articles'
+import Contact from '@/app/components/Home/Contact'
 import Join from '@/app/components/Home/Joinus'
 import Insta from '@/app/components/Home/Insta'
 import { Metadata } from 'next'
@@ -34,6 +35,7 @@ export default function Home() {
       <FAQ />
       <Testimonial />
       <Articles />
+      <Contact />
       <Join />
       <Insta />
     </main>


### PR DESCRIPTION
## Summary
- revamp hero: center copy, add animation, swap CTA to contact
- add new contact section and wire hero button to anchor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_688dc4e0c8288324ab0ce275d45225e3