### PR TITLE
Revamp hero, add contact section, and localize data

### DIFF
--- a/src/app/api/data/route.ts
+++ b/src/app/api/data/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
 import { HeaderItem } from '@/app/types/menu'
 import { aboutdata } from '@/app/types/aboutdata'
@@ -9,292 +9,507 @@ import { articles } from '@/app/types/articles'
 import { footerlinks } from '@/app/types/footerlinks'
 
 // header nav-links data
-const headerData: HeaderItem[] = [
-  { label: 'About Us', href: '#About' },
-  { label: 'Team', href: '#Team' },
-  { label: 'FAQ', href: '#FAQ' },
-  { label: 'Blog', href: '#Blog' },
-  { label: 'Docs', href: '/documentation' },
-]
+const headerData: Record<string, HeaderItem[]> = {
+  en: [
+    { label: 'About Us', href: '#About' },
+    { label: 'Team', href: '#Team' },
+    { label: 'FAQ', href: '#FAQ' },
+    { label: 'Blog', href: '#Blog' },
+    { label: 'Docs', href: '/documentation' },
+  ],
+  vi: [
+    { label: 'Về chúng tôi', href: '#About' },
+    { label: 'Đội ngũ', href: '#Team' },
+    { label: 'Câu hỏi', href: '#FAQ' },
+    { label: 'Blog', href: '#Blog' },
+    { label: 'Tài liệu', href: '/documentation' },
+  ],
+}
 
 // about data
-const Aboutdata: aboutdata[] = [
-  {
-    heading: 'About us.',
-    imgSrc: '/images/aboutus/imgOne.svg',
-    paragraph:
-      'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
-    link: 'Learn more',
-  },
-  {
-    heading: 'Services.',
-    imgSrc: '/images/aboutus/imgTwo.svg',
-    paragraph:
-      'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
-    link: 'Learn more',
-  },
-  {
-    heading: 'Our Works.',
-    imgSrc: '/images/aboutus/imgThree.svg',
-    paragraph:
-      'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
-    link: 'Learn more',
-  },
-]
+const Aboutdata: Record<string, aboutdata[]> = {
+  en: [
+    {
+      heading: 'About us.',
+      imgSrc: '/images/aboutus/imgOne.svg',
+      paragraph:
+        'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
+      link: 'Learn more',
+    },
+    {
+      heading: 'Services.',
+      imgSrc: '/images/aboutus/imgTwo.svg',
+      paragraph:
+        'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
+      link: 'Learn more',
+    },
+    {
+      heading: 'Our Works.',
+      imgSrc: '/images/aboutus/imgThree.svg',
+      paragraph:
+        'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
+      link: 'Learn more',
+    },
+  ],
+  vi: [
+    {
+      heading: 'Về chúng tôi.',
+      imgSrc: '/images/aboutus/imgOne.svg',
+      paragraph:
+        'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
+      link: 'Tìm hiểu thêm',
+    },
+    {
+      heading: 'Dịch vụ.',
+      imgSrc: '/images/aboutus/imgTwo.svg',
+      paragraph:
+        'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
+      link: 'Tìm hiểu thêm',
+    },
+    {
+      heading: 'Dự án của chúng tôi.',
+      imgSrc: '/images/aboutus/imgThree.svg',
+      paragraph:
+        'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem',
+      link: 'Tìm hiểu thêm',
+    },
+  ],
+}
 
-// work-data
-const WorkData: workdata[] = [
-  {
-    profession: 'Co-founder',
-    name: 'John Doe',
-    imgSrc: '/images/wework/avatar.svg',
-  },
-  {
-    profession: 'Co-founder',
-    name: 'John Doe',
-    imgSrc: '/images/wework/avatar3.svg',
-  },
-  {
-    profession: 'Co-founder',
-    name: 'John Doe',
-    imgSrc: '/images/wework/avatar4.svg',
-  },
-  {
-    profession: 'Co-founder',
-    name: 'John Doe',
-    imgSrc: '/images/wework/avatar.svg',
-  },
-  {
-    profession: 'Co-founder',
-    name: 'John Doe',
-    imgSrc: '/images/wework/avatar3.svg',
-  },
-  {
-    profession: 'Co-founder',
-    name: 'John Doe',
-    imgSrc: '/images/wework/avatar4.svg',
-  },
-]
+// work data
+const WorkData: Record<string, workdata[]> = {
+  en: [
+    { profession: 'Co-founder', name: 'John Doe', imgSrc: '/images/wework/avatar.svg' },
+    { profession: 'Co-founder', name: 'John Doe', imgSrc: '/images/wework/avatar3.svg' },
+    { profession: 'Co-founder', name: 'John Doe', imgSrc: '/images/wework/avatar4.svg' },
+    { profession: 'Co-founder', name: 'John Doe', imgSrc: '/images/wework/avatar.svg' },
+    { profession: 'Co-founder', name: 'John Doe', imgSrc: '/images/wework/avatar3.svg' },
+    { profession: 'Co-founder', name: 'John Doe', imgSrc: '/images/wework/avatar4.svg' },
+  ],
+  vi: [
+    { profession: 'Đồng sáng lập', name: 'John Doe', imgSrc: '/images/wework/avatar.svg' },
+    { profession: 'Đồng sáng lập', name: 'John Doe', imgSrc: '/images/wework/avatar3.svg' },
+    { profession: 'Đồng sáng lập', name: 'John Doe', imgSrc: '/images/wework/avatar4.svg' },
+    { profession: 'Đồng sáng lập', name: 'John Doe', imgSrc: '/images/wework/avatar.svg' },
+    { profession: 'Đồng sáng lập', name: 'John Doe', imgSrc: '/images/wework/avatar3.svg' },
+    { profession: 'Đồng sáng lập', name: 'John Doe', imgSrc: '/images/wework/avatar4.svg' },
+  ],
+}
 
 // featured data
-const FeaturedData: featureddata[] = [
-  {
-    heading: 'Brand design for a computer brand.',
-    imgSrc: '/images/featured/feat1.jpg',
-  },
-  {
-    heading: 'Mobile app 3d wallpaper.',
-    imgSrc: '/images/featured/feat2.jpg',
-  },
-  {
-    heading: 'Brand design for a computer brand.',
-    imgSrc: '/images/featured/feat1.jpg',
-  },
-  {
-    heading: 'Mobile app 3d wallpaper.',
-    imgSrc: '/images/featured/feat2.jpg',
-  },
-]
+const FeaturedData: Record<string, featureddata[]> = {
+  en: [
+    { heading: 'Brand design for a computer brand.', imgSrc: '/images/featured/feat1.jpg' },
+    { heading: 'Mobile app 3d wallpaper.', imgSrc: '/images/featured/feat2.jpg' },
+    { heading: 'Brand design for a computer brand.', imgSrc: '/images/featured/feat1.jpg' },
+    { heading: 'Mobile app 3d wallpaper.', imgSrc: '/images/featured/feat2.jpg' },
+  ],
+  vi: [
+    {
+      heading: 'Thiết kế thương hiệu cho một thương hiệu máy tính.',
+      imgSrc: '/images/featured/feat1.jpg',
+    },
+    { heading: 'Hình nền 3D cho ứng dụng di động.', imgSrc: '/images/featured/feat2.jpg' },
+    {
+      heading: 'Thiết kế thương hiệu cho một thương hiệu máy tính.',
+      imgSrc: '/images/featured/feat1.jpg',
+    },
+    { heading: 'Hình nền 3D cho ứng dụng di động.', imgSrc: '/images/featured/feat2.jpg' },
+  ],
+}
 
 // plans data
-const PlansData = [
-  {
-    heading: 'Startup',
-    price: {
-      monthly: 19,
-      yearly: 190,
+const PlansData: Record<string, any[]> = {
+  en: [
+    {
+      heading: 'Startup',
+      price: {
+        monthly: 19,
+        yearly: 190,
+      },
+      user: 'per user',
+      features: {
+        profiles: '5 Social Profiles',
+        posts: '5 Scheduled Posts Per Profile',
+        templates: '400+ Templated',
+        view: 'Calendar View',
+        support: '24/7 Support',
+      },
     },
-    user: 'per user',
-    features: {
-      profiles: '5 Social Profiles',
-      posts: '5 Scheduled Posts Per Profile',
-      templates: '400+ Templated',
-      view: 'Calendar View',
-      support: '24/7 Support',
+    {
+      heading: 'Business',
+      price: {
+        monthly: 29,
+        yearly: 290,
+      },
+      user: 'per user',
+      features: {
+        profiles: '10 Social Profiles',
+        posts: '5 Scheduled Posts Per Profile',
+        templates: '600+ Templated',
+        view: 'Calendar View',
+        support: '24/7 VIP Support',
+      },
     },
-  },
-  {
-    heading: 'Business',
-    price: {
-      monthly: 29,
-      yearly: 290,
+    {
+      heading: 'Agency',
+      price: {
+        monthly: 59,
+        yearly: 590,
+      },
+      user: 'per user',
+      features: {
+        profiles: '100 Social Profiles',
+        posts: '100 Scheduled Posts Per Profile',
+        templates: '800+ Templated',
+        view: 'Calendar View',
+        support: '24/7 VIP Support',
+      },
     },
-    user: 'per user',
-    features: {
-      profiles: '10 Social Profiles',
-      posts: '5 Scheduled Posts Per Profile',
-      templates: '600+ Templated',
-      view: 'Calendar View',
-      support: '24/7 VIP Support',
+  ],
+  vi: [
+    {
+      heading: 'Khởi nghiệp',
+      price: {
+        monthly: 19,
+        yearly: 190,
+      },
+      user: 'mỗi người dùng',
+      features: {
+        profiles: '5 hồ sơ mạng xã hội',
+        posts: '5 bài đăng đã lên lịch mỗi hồ sơ',
+        templates: '400+ mẫu',
+        view: 'Xem theo lịch',
+        support: 'Hỗ trợ 24/7',
+      },
     },
-  },
-  {
-    heading: 'Agency',
-    price: {
-      monthly: 59,
-      yearly: 590,
+    {
+      heading: 'Doanh nghiệp',
+      price: {
+        monthly: 29,
+        yearly: 290,
+      },
+      user: 'mỗi người dùng',
+      features: {
+        profiles: '10 hồ sơ mạng xã hội',
+        posts: '5 bài đăng đã lên lịch mỗi hồ sơ',
+        templates: '600+ mẫu',
+        view: 'Xem theo lịch',
+        support: 'Hỗ trợ VIP 24/7',
+      },
     },
-    user: 'per user',
-    features: {
-      profiles: '100 Social Profiles',
-      posts: '100 Scheduled Posts Per Profile',
-      templates: '800+ Templated',
-      view: 'Calendar View',
-      support: '24/7 VIP Support',
+    {
+      heading: 'Công ty',
+      price: {
+        monthly: 59,
+        yearly: 590,
+      },
+      user: 'mỗi người dùng',
+      features: {
+        profiles: '100 hồ sơ mạng xã hội',
+        posts: '100 bài đăng đã lên lịch mỗi hồ sơ',
+        templates: '800+ mẫu',
+        view: 'Xem theo lịch',
+        support: 'Hỗ trợ VIP 24/7',
+      },
     },
-  },
-]
+  ],
+}
 
-// testimonial data
-const TestimonialsData: testimonials[] = [
-  {
-    name: 'Robert Fox',
-    profession: 'CEO, Parkview Int.Ltd',
-    comment:
-      'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
-    imgSrc: '/images/testimonial/user1.svg',
-    rating: 5,
-  },
-  {
-    name: 'Leslie Alexander',
-    profession: 'CEO, Parkview Int.Ltd',
-    comment:
-      'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
-    imgSrc: '/images/testimonial/user2.svg',
-    rating: 4,
-  },
-  {
-    name: 'Cody Fisher',
-    profession: 'CEO, Parkview Int.Ltd',
-    comment:
-      'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
-    imgSrc: '/images/testimonial/user3.svg',
-    rating: 4,
-  },
-  {
-    name: 'Robert Fox',
-    profession: 'CEO, Parkview Int.Ltd',
-    comment:
-      'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
-    imgSrc: '/images/testimonial/user1.svg',
-    rating: 4,
-  },
-  {
-    name: 'Leslie Alexander',
-    profession: 'CEO, Parkview Int.Ltd',
-    comment:
-      'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
-    imgSrc: '/images/testimonial/user2.svg',
-    rating: 4,
-  },
-  {
-    name: 'Cody Fisher',
-    profession: 'CEO, Parkview Int.Ltd',
-    comment:
-      'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
-    imgSrc: '/images/testimonial/user3.svg',
-    rating: 4,
-  },
-]
+// testimonials data
+const TestimonialsData: Record<string, testimonials[]> = {
+  en: [
+    {
+      name: 'Robert Fox',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
+      imgSrc: '/images/testimonial/user1.svg',
+      rating: 5,
+    },
+    {
+      name: 'Leslie Alexander',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
+      imgSrc: '/images/testimonial/user2.svg',
+      rating: 4,
+    },
+    {
+      name: 'Cody Fisher',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
+      imgSrc: '/images/testimonial/user3.svg',
+      rating: 4,
+    },
+    {
+      name: 'Robert Fox',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
+      imgSrc: '/images/testimonial/user1.svg',
+      rating: 4,
+    },
+    {
+      name: 'Leslie Alexander',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
+      imgSrc: '/images/testimonial/user2.svg',
+      rating: 4,
+    },
+    {
+      name: 'Cody Fisher',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour',
+      imgSrc: '/images/testimonial/user3.svg',
+      rating: 4,
+    },
+  ],
+  vi: [
+    {
+      name: 'Robert Fox',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'Có nhiều biến thể của Lorem Ipsum, nhưng phần lớn đã bị thay đổi theo một cách nào đó do chèn thêm yếu tố hài hước',
+      imgSrc: '/images/testimonial/user1.svg',
+      rating: 5,
+    },
+    {
+      name: 'Leslie Alexander',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'Có nhiều biến thể của Lorem Ipsum, nhưng phần lớn đã bị thay đổi theo một cách nào đó do chèn thêm yếu tố hài hước',
+      imgSrc: '/images/testimonial/user2.svg',
+      rating: 4,
+    },
+    {
+      name: 'Cody Fisher',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'Có nhiều biến thể của Lorem Ipsum, nhưng phần lớn đã bị thay đổi theo một cách nào đó do chèn thêm yếu tố hài hước',
+      imgSrc: '/images/testimonial/user3.svg',
+      rating: 4,
+    },
+    {
+      name: 'Robert Fox',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'Có nhiều biến thể của Lorem Ipsum, nhưng phần lớn đã bị thay đổi theo một cách nào đó do chèn thêm yếu tố hài hước',
+      imgSrc: '/images/testimonial/user1.svg',
+      rating: 4,
+    },
+    {
+      name: 'Leslie Alexander',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'Có nhiều biến thể của Lorem Ipsum, nhưng phần lớn đã bị thay đổi theo một cách nào đó do chèn thêm yếu tố hài hước',
+      imgSrc: '/images/testimonial/user2.svg',
+      rating: 4,
+    },
+    {
+      name: 'Cody Fisher',
+      profession: 'CEO, Parkview Int.Ltd',
+      comment:
+        'Có nhiều biến thể của Lorem Ipsum, nhưng phần lớn đã bị thay đổi theo một cách nào đó do chèn thêm yếu tố hài hước',
+      imgSrc: '/images/testimonial/user3.svg',
+      rating: 4,
+    },
+  ],
+}
 
-// artical data
-const ArticlesData: articles[] = [
-  {
-    time: '5 min',
-    heading: 'We Launch Delia',
-    heading2: 'Webflow this Week!',
-    name: 'Published on Startupon',
-    date: 'february 19, 2025',
-    imgSrc: '/images/articles/article.png',
-  },
-  {
-    time: '5 min',
-    heading: 'We Launch Delia',
-    heading2: 'Webflow this Week!',
-    name: 'Published on Startupon',
-    date: 'february 19, 2025',
-    imgSrc: '/images/articles/article2.png',
-  },
-  {
-    time: '5 min',
-    heading: 'We Launch Delia',
-    heading2: 'Webflow this Week!',
-    name: 'Published on Startupon',
-    date: 'february 19, 2025',
-    imgSrc: '/images/articles/article3.png',
-  },
-  {
-    time: '5 min',
-    heading: 'We Launch Delia',
-    heading2: 'Webflow this Week!',
-    name: 'Published on Startupon',
-    date: 'february 19, 2025',
-    imgSrc: '/images/articles/article.png',
-  },
-  {
-    time: '5 min',
-    heading: 'We Launch Delia',
-    heading2: 'Webflow this Week!',
-    name: 'Published on Startupon',
-    date: 'february 19, 2025',
-    imgSrc: '/images/articles/article2.png',
-  },
-  {
-    time: '5 min',
-    heading: 'We Launch Delia',
-    heading2: 'Webflow this Week!',
-    name: 'Published on Startupon',
-    date: 'february 19, 2025',
-    imgSrc: '/images/articles/article3.png',
-  },
-]
+// articles data
+const ArticlesData: Record<string, articles[]> = {
+  en: [
+    {
+      time: '5 min',
+      heading: 'We Launch Delia',
+      heading2: 'Webflow this Week!',
+      name: 'Published on Startupon',
+      date: 'february 19, 2025',
+      imgSrc: '/images/articles/article.png',
+    },
+    {
+      time: '5 min',
+      heading: 'We Launch Delia',
+      heading2: 'Webflow this Week!',
+      name: 'Published on Startupon',
+      date: 'february 19, 2025',
+      imgSrc: '/images/articles/article2.png',
+    },
+    {
+      time: '5 min',
+      heading: 'We Launch Delia',
+      heading2: 'Webflow this Week!',
+      name: 'Published on Startupon',
+      date: 'february 19, 2025',
+      imgSrc: '/images/articles/article3.png',
+    },
+    {
+      time: '5 min',
+      heading: 'We Launch Delia',
+      heading2: 'Webflow this Week!',
+      name: 'Published on Startupon',
+      date: 'february 19, 2025',
+      imgSrc: '/images/articles/article.png',
+    },
+    {
+      time: '5 min',
+      heading: 'We Launch Delia',
+      heading2: 'Webflow this Week!',
+      name: 'Published on Startupon',
+      date: 'february 19, 2025',
+      imgSrc: '/images/articles/article2.png',
+    },
+    {
+      time: '5 min',
+      heading: 'We Launch Delia',
+      heading2: 'Webflow this Week!',
+      name: 'Published on Startupon',
+      date: 'february 19, 2025',
+      imgSrc: '/images/articles/article3.png',
+    },
+  ],
+  vi: [
+    {
+      time: '5 phút',
+      heading: 'Chúng tôi ra mắt Delia',
+      heading2: 'Webflow tuần này!',
+      name: 'Xuất bản trên Startupon',
+      date: '19 tháng 2, 2025',
+      imgSrc: '/images/articles/article.png',
+    },
+    {
+      time: '5 phút',
+      heading: 'Chúng tôi ra mắt Delia',
+      heading2: 'Webflow tuần này!',
+      name: 'Xuất bản trên Startupon',
+      date: '19 tháng 2, 2025',
+      imgSrc: '/images/articles/article2.png',
+    },
+    {
+      time: '5 phút',
+      heading: 'Chúng tôi ra mắt Delia',
+      heading2: 'Webflow tuần này!',
+      name: 'Xuất bản trên Startupon',
+      date: '19 tháng 2, 2025',
+      imgSrc: '/images/articles/article3.png',
+    },
+    {
+      time: '5 phút',
+      heading: 'Chúng tôi ra mắt Delia',
+      heading2: 'Webflow tuần này!',
+      name: 'Xuất bản trên Startupon',
+      date: '19 tháng 2, 2025',
+      imgSrc: '/images/articles/article.png',
+    },
+    {
+      time: '5 phút',
+      heading: 'Chúng tôi ra mắt Delia',
+      heading2: 'Webflow tuần này!',
+      name: 'Xuất bản trên Startupon',
+      date: '19 tháng 2, 2025',
+      imgSrc: '/images/articles/article2.png',
+    },
+    {
+      time: '5 phút',
+      heading: 'Chúng tôi ra mắt Delia',
+      heading2: 'Webflow tuần này!',
+      name: 'Xuất bản trên Startupon',
+      date: '19 tháng 2, 2025',
+      imgSrc: '/images/articles/article3.png',
+    },
+  ],
+}
 
 // footer links data
-const FooterLinksData: footerlinks[] = [
-  {
-    section: 'Menu',
-    links: [
-      { label: 'About Us', href: '#About' },
-      { label: 'Team', href: '#Team' },
-      { label: 'FAQ', href: '#FAQ' },
-      { label: 'Blog', href: '#Blog' },
-    ],
-  },
-  {
-    section: 'Category',
-    links: [
-      { label: 'Design', href: '/' },
-      { label: 'Mockup', href: '/' },
-      { label: 'View all', href: '/' },
-      { label: 'Log In', href: '/' },
-    ],
-  },
-  {
-    section: 'Pages',
-    links: [
-      { label: '404', href: '/' },
-      { label: 'Instructions', href: '/' },
-      { label: 'License', href: '/' },
-    ],
-  },
-  {
-    section: 'Others',
-    links: [
-      { label: 'Styleguide', href: '/' },
-      { label: 'Changelog', href: '/' },
-    ],
-  },
-]
+const FooterLinksData: Record<string, footerlinks[]> = {
+  en: [
+    {
+      section: 'Menu',
+      links: [
+        { label: 'About Us', href: '#About' },
+        { label: 'Team', href: '#Team' },
+        { label: 'FAQ', href: '#FAQ' },
+        { label: 'Blog', href: '#Blog' },
+      ],
+    },
+    {
+      section: 'Category',
+      links: [
+        { label: 'Design', href: '/' },
+        { label: 'Mockup', href: '/' },
+        { label: 'View all', href: '/' },
+        { label: 'Log In', href: '/' },
+      ],
+    },
+    {
+      section: 'Pages',
+      links: [
+        { label: '404', href: '/' },
+        { label: 'Instructions', href: '/' },
+        { label: 'License', href: '/' },
+      ],
+    },
+    {
+      section: 'Others',
+      links: [
+        { label: 'Styleguide', href: '/' },
+        { label: 'Changelog', href: '/' },
+      ],
+    },
+  ],
+  vi: [
+    {
+      section: 'Menu',
+      links: [
+        { label: 'Về chúng tôi', href: '#About' },
+        { label: 'Đội ngũ', href: '#Team' },
+        { label: 'Câu hỏi', href: '#FAQ' },
+        { label: 'Blog', href: '#Blog' },
+      ],
+    },
+    {
+      section: 'Danh mục',
+      links: [
+        { label: 'Thiết kế', href: '/' },
+        { label: 'Mockup', href: '/' },
+        { label: 'Xem tất cả', href: '/' },
+        { label: 'Đăng nhập', href: '/' },
+      ],
+    },
+    {
+      section: 'Trang',
+      links: [
+        { label: '404', href: '/' },
+        { label: 'Hướng dẫn', href: '/' },
+        { label: 'Giấy phép', href: '/' },
+      ],
+    },
+    {
+      section: 'Khác',
+      links: [
+        { label: 'Hướng dẫn phong cách', href: '/' },
+        { label: 'Changelog', href: '/' },
+      ],
+    },
+  ],
+}
 
-export const GET = () => {
+export const GET = (req: NextRequest) => {
+  const lang = req.nextUrl.searchParams.get('lang') === 'vi' ? 'vi' : 'en'
+
   return NextResponse.json({
-    headerData,
-    Aboutdata,
-    WorkData,
-    FeaturedData,
-    PlansData,
-    TestimonialsData,
-    ArticlesData,
-    FooterLinksData,
+    headerData: headerData[lang],
+    Aboutdata: Aboutdata[lang],
+    WorkData: WorkData[lang],
+    FeaturedData: FeaturedData[lang],
+    PlansData: PlansData[lang],
+    TestimonialsData: TestimonialsData[lang],
+    ArticlesData: ArticlesData[lang],
+    FooterLinksData: FooterLinksData[lang],
   })
 }
+

--- a/src/app/components/Common/LanguageSwitcher.tsx
+++ b/src/app/components/Common/LanguageSwitcher.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useI18n } from "@/utils/i18n";
+
+interface Props {
+  className?: string;
+}
+
+const LanguageSwitcher: React.FC<Props> = ({ className = "" }) => {
+  const { lang } = useI18n();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("lang", e.target.value);
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  return (
+    <select
+      value={lang}
+      onChange={handleChange}
+      className={`bg-transparent border border-darkmode rounded-lg px-2 py-1 text-darkmode cursor-pointer ${className}`}
+    >
+      <option value="en">EN</option>
+      <option value="vi">VI</option>
+      <option value="ja">JA</option>
+    </select>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/app/components/Home/AboutUs/index.tsx
+++ b/src/app/components/Home/AboutUs/index.tsx
@@ -5,16 +5,18 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { Icon } from '@iconify/react'
 import AboutSkeleton from '../../Skeleton/AboutUs'
+import { useI18n } from '@/utils/i18n'
 
 const Aboutus = () => {
   // fetch about data
   const [about, setAbout] = useState<aboutdata[]>([])
   const [loading, setLoading] = useState(true)
+  const { lang } = useI18n()
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/data')
+        const res = await fetch(`/api/data?lang=${lang}`)
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setAbout(data.Aboutdata)
@@ -25,7 +27,7 @@ const Aboutus = () => {
       }
     }
     fetchData()
-  }, [])
+  }, [lang])
 
   return (
     <section id='About' className=' bg-cover bg-center overflow-hidden'>

--- a/src/app/components/Home/Articles/index.tsx
+++ b/src/app/components/Home/Articles/index.tsx
@@ -5,6 +5,7 @@ import Slider from 'react-slick'
 import Link from 'next/link'
 import { articles } from '@/app/types/articles'
 import ArticlesSkeleton from '../../Skeleton/Articles'
+import { useI18n } from '@/utils/i18n'
 
 const settings = {
   dots: true,
@@ -40,11 +41,12 @@ const Articles = () => {
 
   const [articles, setArticles] = useState<articles[]>([])
   const [loading, setLoading] = useState(true)
+  const { lang } = useI18n()
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/data')
+        const res = await fetch(`/api/data?lang=${lang}`)
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setArticles(data.ArticlesData)
@@ -56,7 +58,7 @@ const Articles = () => {
     }
 
     fetchData()
-  }, [])
+  }, [lang])
 
   return (
     <section id='Blog' className='relative bg-grey overflow-hidden'>

--- a/src/app/components/Home/Contact/index.tsx
+++ b/src/app/components/Home/Contact/index.tsx
@@ -1,0 +1,47 @@
+'use client'
+import React from 'react'
+import { useI18n } from '@/utils/i18n'
+
+const Contact = () => {
+  const { t } = useI18n()
+  return (
+    <section id='contact' className='py-20'>
+      <div className='container mx-auto max-w-7xl px-4 text-center'>
+        <p className='text-primary text-lg font-normal tracking-widest uppercase'>{t('CONTACT')}</p>
+        <h2 className='my-6'>{t('CONTACT_TAGLINE')}</h2>
+        <p className='text-black/50 text-base max-w-3xl mx-auto mb-8'>
+          {t('CONTACT_DESC')}
+        </p>
+        <div className='max-w-3xl mx-auto'>
+          <form className='grid gap-6'>
+            <input
+              type='text'
+              className='py-4 px-6 rounded-md bg-grey focus:outline-hidden'
+              placeholder={t('NAME_PLACEHOLDER')}
+              autoComplete='off'
+            />
+            <input
+              type='email'
+              className='py-4 px-6 rounded-md bg-grey focus:outline-hidden'
+              placeholder={t('EMAIL_PLACEHOLDER')}
+              autoComplete='off'
+            />
+            <textarea
+              className='py-4 px-6 rounded-md bg-grey focus:outline-hidden h-40'
+              placeholder={t('MESSAGE_PLACEHOLDER')}
+              autoComplete='off'
+            />
+            <button
+              type='submit'
+              className='bg-primary text-white text-xl font-semibold py-5 px-12 rounded-full hover:bg-darkmode duration-300 w-fit mx-auto'
+            >
+              {t('SEND_MESSAGE')}
+            </button>
+          </form>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default Contact

--- a/src/app/components/Home/Featured/index.tsx
+++ b/src/app/components/Home/Featured/index.tsx
@@ -6,6 +6,7 @@ import 'slick-carousel/slick/slick-theme.css'
 import Image from 'next/image'
 import { featureddata } from '@/app/types/featureddata'
 import FeaturedSkeleton from '../../Skeleton/Featured'
+import { useI18n } from '@/utils/i18n'
 
 function SampleNextArrow(props: { className: any; style: any; onClick: any }) {
   const { className, style, onClick } = props
@@ -82,11 +83,12 @@ const settings = {
 const Featured = () => {
   const [featured, setFeatured] = useState<featureddata[]>([])
   const [loading, setLoading] = useState(true)
+  const { lang } = useI18n()
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/data')
+        const res = await fetch(`/api/data?lang=${lang}`)
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setFeatured(data.FeaturedData)
@@ -98,7 +100,7 @@ const Featured = () => {
     }
 
     fetchData()
-  }, [])
+  }, [lang])
 
   return (
     <section className="relative bg-deepSlate dark:bg-darkmode  after:absolute after:w-1/4 after:h-1/4 after:bg-[url('/images/wework/vector.svg')]  after:top-72 after:right-0 after:bg-no-repeat">

--- a/src/app/components/Home/Hero/index.tsx
+++ b/src/app/components/Home/Hero/index.tsx
@@ -1,51 +1,56 @@
+
 'use client'
 import Link from 'next/link'
-import Image from 'next/image'
 import { motion } from 'framer-motion'
-import { Icon } from '@iconify/react/dist/iconify.js'
+import { useI18n } from '@/utils/i18n'
 
 const Hero = () => {
-  const leftAnimation = {
-    initial: { x: '-100%', opacity: 0 },
-    animate: { x: 0, opacity: 1 },
-    exit: { x: '-100%', opacity: 0 },
-    transition: { duration: 0.6 },
-  }
-
-  const rightAnimation = {
-    initial: { x: '100%', opacity: 0 },
-    animate: { x: 0, opacity: 1 },
-    exit: { x: '100%', opacity: 0 },
+  const { t } = useI18n()
+  const fadeUp = {
+    initial: { opacity: 0, y: 40 },
+    animate: { opacity: 1, y: 0 },
     transition: { duration: 0.6 },
   }
 
   return (
     <section className='relative overflow-hidden z-1'>
       <div className='container mx-auto pt-24 max-w-7xl px-4'>
-        <div className='grid grid-cols-12 justify-center items-center'>
-          <div className='col-span-12 xl:col-span-5 lg:col-span-6 md:col-span-12 sm:col-span-12'>
-            <div className='py-2 px-5 bg-primary/15 rounded-full w-fit'>
-              <p className='text-primary text-lg font-bold'>DESIGN AGENCY</p>
-            </div>
-            <h1>
-              Dedicated to bring your ideas to life.
-            </h1>
-            <Link href={'#'}>
-              <button className='bg-primary text-white text-xl font-semibold py-5 px-12 rounded-full hover:bg-darkmode hover:cursor-pointer mt-10'>
-                Get started
+        <div className='flex flex-col items-center text-center'>
+          <motion.div
+            {...fadeUp}
+            className='py-2 px-5 bg-primary/15 rounded-full mb-6'
+          >
+            <p className='text-primary text-lg font-bold'>{t('DESIGN_AGENCY')}</p>
+          </motion.div>
+          <motion.h1
+            {...fadeUp}
+            transition={{ duration: 0.6, delay: 0.2 }}
+          >
+            {t('HERO_TITLE')}
+          </motion.h1>
+          <motion.div
+            {...fadeUp}
+            transition={{ duration: 0.6, delay: 0.4 }}
+            className='mt-10'
+          >
+            <Link href='#contact'>
+              <button className='bg-primary text-white text-xl font-semibold py-5 px-12 rounded-full hover:bg-darkmode hover:cursor-pointer'>
+                {t('CONTACT_NOW')}
               </button>
             </Link>
-          </div>
-          <div className='xl:col-span-7 lg:col-span-6 lg:block hidden'>
-            <Image
-              src='/images/hero/banner-image.png'
-              alt='banner image'
-              width={600}
-              height={600}
-              className='w-full'
-            />
-          </div>
+          </motion.div>
         </div>
+        {/*
+        <div className='xl:col-span-7 lg:col-span-6 lg:block hidden'>
+          <Image
+            src='/images/hero/banner-image.png'
+            alt='banner image'
+            width={600}
+            height={600}
+            className='w-full'
+          />
+        </div>
+        */}
       </div>
     </section>
   )

--- a/src/app/components/Home/Manage/index.tsx
+++ b/src/app/components/Home/Manage/index.tsx
@@ -4,14 +4,16 @@ import { Switch } from '@headlessui/react'
 import Image from 'next/image'
 import PlansSkeleton from '../../Skeleton/Plans'
 import Link from 'next/link'
+import { useI18n } from '@/utils/i18n'
 
 const Manage = () => {
   const [plans, setPlans] = useState<any[]>([])
   const [loading, setLoding] = useState(true)
+  const { lang } = useI18n()
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/data')
+        const res = await fetch(`/api/data?lang=${lang}`)
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setPlans(data.PlansData)
@@ -22,7 +24,7 @@ const Manage = () => {
       }
     }
     fetchData()
-  }, [])
+  }, [lang])
 
   const [enabled, setEnabled] = useState(false)
   const [selectedCategory, setSelectedCategory] = useState<

--- a/src/app/components/Home/Testimonials/index.tsx
+++ b/src/app/components/Home/Testimonials/index.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { Icon } from '@iconify/react'
 import { testimonials } from '@/app/types/testimonials'
 import TestimonialSkeleton from '../../Skeleton/Testimonial'
+import { useI18n } from '@/utils/i18n'
 
 interface TestimonialType {
   name: string
@@ -103,11 +104,12 @@ const Testimonial: React.FC = () => {
   // fetch data
   const [testimonals, setTestimonials] = useState<testimonials[]>([])
   const [loading, setLoading] = useState(true)
+  const { lang } = useI18n()
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/data')
+        const res = await fetch(`/api/data?lang=${lang}`)
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setTestimonials(data.TestimonialsData)
@@ -118,7 +120,7 @@ const Testimonial: React.FC = () => {
       }
     }
     fetchData()
-  }, [])
+  }, [lang])
 
   return (
     <section

--- a/src/app/components/Home/Work/index.tsx
+++ b/src/app/components/Home/Work/index.tsx
@@ -6,6 +6,7 @@ import 'slick-carousel/slick/slick-theme.css'
 import Slider from 'react-slick'
 import { workdata } from '@/app/types/workdata'
 import WorkSkeleton from '../../Skeleton/Work'
+import { useI18n } from '@/utils/i18n'
 
 const settings = {
   dots: false,
@@ -52,11 +53,12 @@ const Work = () => {
   // fetch work data
   const [work, setWork] = useState<workdata[]>([])
   const [loading, setLoding] = useState(true)
+  const { lang } = useI18n()
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/data')
+        const res = await fetch(`/api/data?lang=${lang}`)
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setWork(data.WorkData)
@@ -68,7 +70,7 @@ const Work = () => {
     }
 
     fetchData()
-  }, [])
+  }, [lang])
 
   return (
     <section

--- a/src/app/components/Layout/Footer/index.tsx
+++ b/src/app/components/Layout/Footer/index.tsx
@@ -4,16 +4,18 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { footerlinks } from '@/app/types/footerlinks'
+import { useI18n } from '@/utils/i18n'
 
 const footer = () => {
   // fetch data
 
   const [footerlinks, setFooterLinks] = useState<footerlinks[]>([])
+  const { lang } = useI18n()
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/data')
+        const res = await fetch(`/api/data?lang=${lang}`)
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setFooterLinks(data.FooterLinksData)
@@ -22,7 +24,7 @@ const footer = () => {
       }
     }
     fetchData()
-  }, [])
+  }, [lang])
 
   return (
     <div className='bg-black' id='first-section'>

--- a/src/app/components/Layout/Header/index.tsx
+++ b/src/app/components/Layout/Header/index.tsx
@@ -10,12 +10,14 @@ import MobileHeaderLink from './Navigation/MobileHeaderLink'
 import Signin from '@/app/components/Auth/SignIn'
 import SignUp from '@/app/components/Auth/SignUp'
 import { Icon } from '@iconify/react/dist/iconify.js'
+import { useI18n } from '@/utils/i18n'
 
 const Header: React.FC = () => {
   const [navbarOpen, setNavbarOpen] = useState(false)
   const [sticky, setSticky] = useState(false)
   const [isSignInOpen, setIsSignInOpen] = useState(false)
   const [isSignUpOpen, setIsSignUpOpen] = useState(false)
+  const { lang } = useI18n()
 
   const navbarRef = useRef<HTMLDivElement>(null)
   const signInRef = useRef<HTMLDivElement>(null)
@@ -72,7 +74,7 @@ const Header: React.FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/data')
+        const res = await fetch(`/api/data?lang=${lang}`)
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setHeaderData(data.headerData)
@@ -81,7 +83,7 @@ const Header: React.FC = () => {
       }
     }
     fetchData()
-  }, [])
+  }, [lang])
 
   return (
     <header

--- a/src/app/components/Layout/Header/index.tsx
+++ b/src/app/components/Layout/Header/index.tsx
@@ -1,131 +1,137 @@
-'use client'
-import { Key, useEffect, useRef, useState } from 'react'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import { useTheme } from 'next-themes'
-import { HeaderItem } from '@/app/types/menu'
-import Logo from './Logo'
-import HeaderLink from './Navigation/HeaderLink'
-import MobileHeaderLink from './Navigation/MobileHeaderLink'
-import Signin from '@/app/components/Auth/SignIn'
-import SignUp from '@/app/components/Auth/SignUp'
-import { Icon } from '@iconify/react/dist/iconify.js'
-import { useI18n } from '@/utils/i18n'
+"use client";
+import { Key, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { HeaderItem } from "@/app/types/menu";
+import Logo from "./Logo";
+import HeaderLink from "./Navigation/HeaderLink";
+import MobileHeaderLink from "./Navigation/MobileHeaderLink";
+import Signin from "@/app/components/Auth/SignIn";
+import SignUp from "@/app/components/Auth/SignUp";
+import { Icon } from "@iconify/react/dist/iconify.js";
+import { useI18n } from "@/utils/i18n";
+import LanguageSwitcher from "@/app/components/Common/LanguageSwitcher";
 
 const Header: React.FC = () => {
-  const [navbarOpen, setNavbarOpen] = useState(false)
-  const [sticky, setSticky] = useState(false)
-  const [isSignInOpen, setIsSignInOpen] = useState(false)
-  const [isSignUpOpen, setIsSignUpOpen] = useState(false)
-  const { lang } = useI18n()
+  const [navbarOpen, setNavbarOpen] = useState(false);
+  const [sticky, setSticky] = useState(false);
+  const [isSignInOpen, setIsSignInOpen] = useState(false);
+  const [isSignUpOpen, setIsSignUpOpen] = useState(false);
+  const { lang } = useI18n();
 
-  const navbarRef = useRef<HTMLDivElement>(null)
-  const signInRef = useRef<HTMLDivElement>(null)
-  const signUpRef = useRef<HTMLDivElement>(null)
-  const mobileMenuRef = useRef<HTMLDivElement>(null)
+  const navbarRef = useRef<HTMLDivElement>(null);
+  const signInRef = useRef<HTMLDivElement>(null);
+  const signUpRef = useRef<HTMLDivElement>(null);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
 
   const handleScroll = () => {
-    setSticky(window.scrollY >= 80)
-  }
+    setSticky(window.scrollY >= 80);
+  };
 
   const handleClickOutside = (event: MouseEvent) => {
     if (
       signInRef.current &&
       !signInRef.current.contains(event.target as Node)
     ) {
-      setIsSignInOpen(false)
+      setIsSignInOpen(false);
     }
     if (
       signUpRef.current &&
       !signUpRef.current.contains(event.target as Node)
     ) {
-      setIsSignUpOpen(false)
+      setIsSignUpOpen(false);
     }
     if (
       mobileMenuRef.current &&
       !mobileMenuRef.current.contains(event.target as Node) &&
       navbarOpen
     ) {
-      setNavbarOpen(false)
+      setNavbarOpen(false);
     }
-  }
+  };
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll)
-    document.addEventListener('mousedown', handleClickOutside)
+    window.addEventListener("scroll", handleScroll);
+    document.addEventListener("mousedown", handleClickOutside);
     return () => {
-      window.removeEventListener('scroll', handleScroll)
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [navbarOpen, isSignInOpen, isSignUpOpen])
+      window.removeEventListener("scroll", handleScroll);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [navbarOpen, isSignInOpen, isSignUpOpen]);
 
   useEffect(() => {
     if (isSignInOpen || isSignUpOpen || navbarOpen) {
-      document.body.style.overflow = 'hidden'
+      document.body.style.overflow = "hidden";
     } else {
-      document.body.style.overflow = ''
+      document.body.style.overflow = "";
     }
-  }, [isSignInOpen, isSignUpOpen, navbarOpen])
+  }, [isSignInOpen, isSignUpOpen, navbarOpen]);
 
   // header data fetch
 
-  const [headerData, setHeaderData] = useState<HeaderItem[]>([])
+  const [headerData, setHeaderData] = useState<HeaderItem[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch(`/api/data?lang=${lang}`)
-        if (!res.ok) throw new Error('Failed to fetch')
-        const data = await res.json()
-        setHeaderData(data.headerData)
+        const res = await fetch(`/api/data?lang=${lang}`);
+        if (!res.ok) throw new Error("Failed to fetch");
+        const data = await res.json();
+        setHeaderData(data.headerData);
       } catch (error) {
-        console.error('Error fetching services:', error)
+        console.error("Error fetching services:", error);
       }
-    }
-    fetchData()
-  }, [lang])
+    };
+    fetchData();
+  }, [lang]);
 
   return (
     <header
       className={`fixed top-0 z-40 w-full transition-all duration-300 border-b border-black/10 ${
-        sticky ? ' shadow-lg bg-white' : 'shadow-none'
-      }`}>
-      <div className='lg:py-0 py-2'>
-        <div className='container mx-auto max-w-(--breakpoint-xl) flex items-center justify-between px-4'>
+        sticky ? " shadow-lg bg-white" : "shadow-none"
+      }`}
+    >
+      <div className="lg:py-0 py-2">
+        <div className="container mx-auto max-w-(--breakpoint-xl) flex items-center justify-between px-4">
           <div
             className={`pr-16 lg:border-r border-black/10 duration-300 ${
-              sticky ? 'py-3' : 'py-7'
-            }`}>
+              sticky ? "py-3" : "py-7"
+            }`}
+          >
             <Logo />
           </div>
-          <nav className='hidden lg:flex grow items-center gap-8 justify-center'>
+          <nav className="hidden lg:flex grow items-center gap-8 justify-center">
             {headerData.map((item, index) => (
               <HeaderLink key={index} item={item} />
             ))}
           </nav>
           <div
             className={`flex items-center gap-4 pl-16 lg:border-l border-black/10 duration-300 ${
-              sticky ? 'py-3' : 'py-7'
-            }`}>
+              sticky ? "py-3" : "py-7"
+            }`}
+          >
+            <LanguageSwitcher className="hidden lg:block" />
             <button
-              className='hidden lg:block bg-transparent text-darkmode border hover:bg-darkmode border-darkmode hover:text-white px-4 py-2 rounded-lg hover:cursor-pointer'
+              className="hidden lg:block bg-transparent text-darkmode border hover:bg-darkmode border-darkmode hover:text-white px-4 py-2 rounded-lg hover:cursor-pointer"
               onClick={() => {
-                setIsSignInOpen(true)
-              }}>
+                setIsSignInOpen(true);
+              }}
+            >
               Sign In
             </button>
             {isSignInOpen && (
-              <div className='fixed top-0 left-0 w-full h-full bg-black/50 flex items-center justify-center z-50'>
+              <div className="fixed top-0 left-0 w-full h-full bg-black/50 flex items-center justify-center z-50">
                 <div
                   ref={signInRef}
-                  className='relative mx-auto w-full max-w-md bg-white overflow-hidden rounded-lg px-8 pt-14 pb-8 text-center bg-dark_grey/90 backdrop-blur-md'>
+                  className="relative mx-auto w-full max-w-md bg-white overflow-hidden rounded-lg px-8 pt-14 pb-8 text-center bg-dark_grey/90 backdrop-blur-md"
+                >
                   <button
                     onClick={() => setIsSignInOpen(false)}
-                    className='absolute top-0 right-0 mr-8 mt-8 dark:invert'
-                    aria-label='Close Sign In Modal'>
+                    className="absolute top-0 right-0 mr-8 mt-8 dark:invert"
+                    aria-label="Close Sign In Modal"
+                  >
                     <Icon
-                      icon='tabler:currency-xrp'
-                      className='text-black hover:text-primary text-24 inline-block me-2 cursor-pointer'
+                      icon="tabler:currency-xrp"
+                      className="text-black hover:text-primary text-24 inline-block me-2 cursor-pointer"
                     />
                   </button>
                   <Signin />
@@ -133,24 +139,27 @@ const Header: React.FC = () => {
               </div>
             )}
             <button
-              className='hidden lg:block bg-darkmode text-white hover:bg-transparent hover:text-darkmode border border-darkmode px-4 py-2 rounded-lg hover:cursor-pointer'
+              className="hidden lg:block bg-darkmode text-white hover:bg-transparent hover:text-darkmode border border-darkmode px-4 py-2 rounded-lg hover:cursor-pointer"
               onClick={() => {
-                setIsSignUpOpen(true)
-              }}>
+                setIsSignUpOpen(true);
+              }}
+            >
               Sign Up
             </button>
             {isSignUpOpen && (
-              <div className='fixed top-0 left-0 w-full h-full bg-black/50 flex items-center justify-center z-50'>
+              <div className="fixed top-0 left-0 w-full h-full bg-black/50 flex items-center justify-center z-50">
                 <div
                   ref={signUpRef}
-                  className='relative mx-auto w-full max-w-md overflow-hidden bg-white rounded-lg bg-dark_grey/90 backdrop-blur-md px-8 pt-14 pb-8 text-center'>
+                  className="relative mx-auto w-full max-w-md overflow-hidden bg-white rounded-lg bg-dark_grey/90 backdrop-blur-md px-8 pt-14 pb-8 text-center"
+                >
                   <button
                     onClick={() => setIsSignUpOpen(false)}
-                    className='absolute top-0 right-0 mr-8 mt-8 dark:invert'
-                    aria-label='Close Sign Up Modal'>
+                    className="absolute top-0 right-0 mr-8 mt-8 dark:invert"
+                    aria-label="Close Sign Up Modal"
+                  >
                     <Icon
-                      icon='tabler:currency-xrp'
-                      className='text-black hover:text-primary text-24 inline-block me-2 cursor-pointer'
+                      icon="tabler:currency-xrp"
+                      className="text-black hover:text-primary text-24 inline-block me-2 cursor-pointer"
                     />
                   </button>
                   <SignUp />
@@ -159,24 +168,26 @@ const Header: React.FC = () => {
             )}
             <button
               onClick={() => setNavbarOpen(!navbarOpen)}
-              className='block lg:hidden p-2 rounded-lg'
-              aria-label='Toggle mobile menu'>
-              <span className='block w-6 h-0.5 bg-darkmode'></span>
-              <span className='block w-6 h-0.5 bg-darkmode mt-1.5'></span>
-              <span className='block w-6 h-0.5 bg-darkmode mt-1.5'></span>
+              className="block lg:hidden p-2 rounded-lg"
+              aria-label="Toggle mobile menu"
+            >
+              <span className="block w-6 h-0.5 bg-darkmode"></span>
+              <span className="block w-6 h-0.5 bg-darkmode mt-1.5"></span>
+              <span className="block w-6 h-0.5 bg-darkmode mt-1.5"></span>
             </button>
           </div>
         </div>
         {navbarOpen && (
-          <div className='fixed top-0 left-0 w-full h-full bg-black/50 z-40' />
+          <div className="fixed top-0 left-0 w-full h-full bg-black/50 z-40" />
         )}
         <div
           ref={mobileMenuRef}
           className={`lg:hidden fixed top-0 right-0 h-full w-full bg-darkmode shadow-lg transform transition-transform duration-300 max-w-xs ${
-            navbarOpen ? 'translate-x-0' : 'translate-x-full'
-          } z-50`}>
-          <div className='flex items-center justify-between p-4'>
-            <h2 className='text-lg font-bold text-midnight_text dark:text-midnight_text text-white'>
+            navbarOpen ? "translate-x-0" : "translate-x-full"
+          } z-50`}
+        >
+          <div className="flex items-center justify-between p-4">
+            <h2 className="text-lg font-bold text-midnight_text dark:text-midnight_text text-white">
               <Logo />
             </h2>
 
@@ -184,31 +195,35 @@ const Header: React.FC = () => {
             <button
               onClick={() => setNavbarOpen(false)}
               className="bg-[url('/images/closed.svg')] bg-no-repeat bg-contain w-5 h-5 absolute top-0 right-0 mr-8 mt-8 dark:invert"
-              aria-label='Close menu Modal'></button>
+              aria-label="Close menu Modal"
+            ></button>
           </div>
-          <nav className='flex flex-col items-start p-4'>
+          <nav className="flex flex-col items-start p-4">
             {headerData.map(
               (item: HeaderItem, index: Key | null | undefined) => (
                 <MobileHeaderLink key={index} item={item} />
-              )
+              ),
             )}
-            <div className='mt-4 flex flex-col space-y-4 w-full'>
+            <LanguageSwitcher className="w-full mt-4 px-4 py-2 rounded-lg border-white text-white" />
+            <div className="mt-4 flex flex-col space-y-4 w-full">
               <Link
-                href='#'
-                className='bg-transparent border border-primary text-primary px-4 py-2 rounded-lg hover:bg-blue-600 hover:text-white'
+                href="#"
+                className="bg-transparent border border-primary text-primary px-4 py-2 rounded-lg hover:bg-blue-600 hover:text-white"
                 onClick={() => {
-                  setIsSignInOpen(true)
-                  setNavbarOpen(false)
-                }}>
+                  setIsSignInOpen(true);
+                  setNavbarOpen(false);
+                }}
+              >
                 Sign In
               </Link>
               <Link
-                href='#'
-                className='bg-primary text-white px-4 py-2 rounded-lg hover:bg-blue-700'
+                href="#"
+                className="bg-primary text-white px-4 py-2 rounded-lg hover:bg-blue-700"
                 onClick={() => {
-                  setIsSignUpOpen(true)
-                  setNavbarOpen(false)
-                }}>
+                  setIsSignUpOpen(true);
+                  setNavbarOpen(false);
+                }}
+              >
                 Sign Up
               </Link>
             </div>
@@ -216,7 +231,7 @@ const Header: React.FC = () => {
         </div>
       </div>
     </header>
-  )
-}
+  );
+};
 
-export default Header
+export default Header;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import Manage from '@/app/components/Home/Manage'
 import FAQ from '@/app/components/Home/FAQ'
 import Testimonial from '@/app/components/Home/Testimonials'
 import Articles from '@/app/components/Home/Articles'
+import Contact from '@/app/components/Home/Contact'
 import Join from '@/app/components/Home/Joinus'
 import Insta from '@/app/components/Home/Insta'
 import { Metadata } from 'next'
@@ -34,6 +35,7 @@ export default function Home() {
       <FAQ />
       <Testimonial />
       <Articles />
+      <Contact />
       <Join />
       <Insta />
     </main>

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1,0 +1,12 @@
+export default {
+  DESIGN_AGENCY: 'Creative Agency',
+  HERO_TITLE: 'We turn bold ideas into digital reality.',
+  CONTACT_NOW: 'Contact now',
+  CONTACT: 'Contact',
+  CONTACT_TAGLINE: "Let's build something great together",
+  CONTACT_DESC: "We'd love to hear from you. Send us a message and we will respond as soon as possible.",
+  NAME_PLACEHOLDER: 'Your name',
+  EMAIL_PLACEHOLDER: 'Your email',
+  MESSAGE_PLACEHOLDER: 'Your message',
+  SEND_MESSAGE: 'Send message',
+}

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1,0 +1,12 @@
+export default {
+  DESIGN_AGENCY: 'クリエイティブエージェンシー',
+  HERO_TITLE: '大胆なアイデアをデジタルの現実にします。',
+  CONTACT_NOW: '今すぐお問い合わせ',
+  CONTACT: 'お問い合わせ',
+  CONTACT_TAGLINE: '一緒に素晴らしいものを作りましょう',
+  CONTACT_DESC: 'ご連絡をお待ちしております。メッセージを送っていただければ、すぐに返信いたします。',
+  NAME_PLACEHOLDER: 'お名前',
+  EMAIL_PLACEHOLDER: 'メールアドレス',
+  MESSAGE_PLACEHOLDER: 'メッセージ',
+  SEND_MESSAGE: 'メッセージを送る',
+}

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -1,0 +1,12 @@
+export default {
+  DESIGN_AGENCY: 'Agency Sáng Tạo',
+  HERO_TITLE: 'Chúng tôi biến ý tưởng táo bạo thành hiện thực số.',
+  CONTACT_NOW: 'Liên hệ ngay',
+  CONTACT: 'Liên hệ',
+  CONTACT_TAGLINE: 'Hãy cùng xây dựng điều tuyệt vời',
+  CONTACT_DESC: 'Chúng tôi mong nhận được từ bạn. Gửi tin nhắn và chúng tôi sẽ phản hồi sớm nhất.',
+  NAME_PLACEHOLDER: 'Tên của bạn',
+  EMAIL_PLACEHOLDER: 'Email của bạn',
+  MESSAGE_PLACEHOLDER: 'Tin nhắn của bạn',
+  SEND_MESSAGE: 'Gửi tin nhắn',
+}

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+import en from '@/lang/en'
+import vi from '@/lang/vi'
+import ja from '@/lang/ja'
+
+const resources = { en, vi, ja } as const
+
+type Lang = keyof typeof resources
+
+export function useI18n() {
+  const params = useSearchParams()
+  const lang = (params.get('lang') || 'en') as Lang
+
+  const t = (key: keyof typeof en) => {
+    return resources[lang][key] || key
+  }
+
+  return { t, lang }
+}


### PR DESCRIPTION
## Summary
- revamp hero: center copy, add animation, swap CTA to contact
- add new contact section and wire hero button to anchor
- localize API route to serve English or Vietnamese content via `lang` query param
- add JA/VI/EN i18n files and hook to translate hero and contact sections
- propagate `lang` query param when fetching API data so header, footer, and home sections update on language switch

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint setup)*
- `npm run build` *(fails to fetch font `Manrope` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688dc4e0c8288324ab0ce275d45225e3